### PR TITLE
Add build wheel step in run-downstream-tests workflow

### DIFF
--- a/.github/workflows/run-downstream-tests.yml
+++ b/.github/workflows/run-downstream-tests.yml
@@ -17,19 +17,74 @@ on:
     paths:
       - '**.py'
 
+env:
+  LANG: en_US.utf-8
+  LC_ALL: en_US.utf-8
+  PYTHON_VERSION: '3.8'
+
 jobs:
+
   dispatch:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+
     strategy:
       matrix:
         repo: [ 'VOLTTRON/volttron-openadr-ven', 'VOLTTRON/volttron-listener-agent' ]
+
     steps:
-      - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v1.1.3
-        with:
-          token: ${{ secrets.ACTION_HOOK_TOKEN }}
-          repository: ${{ matrix.repo }}
-          event-type: downstream-testing
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+        - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+        - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+        - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+
+        #----------------------------------------------
+        #       check-out repo and set-up python
+        #----------------------------------------------
+        - name: Checkout code
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+        - name: Set up Python ${{ env.PYTHON_VERSION }}
+          id: setup-python
+          uses: actions/setup-python@v2
+          with:
+            python-version: ${{ env.PYTHON_VERSION }}
+
+        #----------------------------------------------
+        #  -----  install & configure poetry  -----
+        #----------------------------------------------
+        - name: Install Poetry
+          uses: snok/install-poetry@v1
+          with:
+            virtualenvs-create: true
+            virtualenvs-in-project: true
+            installer-parallel: true
+
+        #----------------------------------------------
+        # install your root project, if required
+        #----------------------------------------------
+        - name: Install library
+          run: poetry install --no-interaction
+
+        - name: Create build artifacts
+          run: |
+            poetry build -vvv
+
+        - name: Check if wheels were built
+          run: |
+            ls -lh dist
+
+        - name: Upload wheels as artifact
+          uses: actions/upload-artifact@v2
+          with:
+            name: dist
+            path: dist
+
+        - name: Repository Dispatch
+          uses: peter-evans/repository-dispatch@v1.1.3
+          with:
+            token: ${{ secrets.ACTION_HOOK_TOKEN }}
+            repository: ${{ matrix.repo }}
+            event-type: downstream-testing
+            client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "repository": "${{ github.repository }}", "api_url": "${{ github.api_url }}" }'
 
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ By default, poetry creates a virtual environment in {cache-dir}/virtualenvs
 ({cache-dir}\virtualenvs on Windows). To configure 'poetry' to create the virtualenv inside this project's root
 directory, run the following command:
 
-[```poetry config virtualenvs.in-project true```](https://python-poetry.org/docs/configuration
-)
+[```poetry config virtualenvs.in-project true```](https://python-poetry.org/docs/configuration)
 
 Then to create the virtual environment, run the following command:
 


### PR DESCRIPTION
* Addresses step 2 of the upstream workflow as seen in #11 
* Adds step to build wheels and upload them as artifacts for later retrieval by the corresponding downstream workflows 
* Fixes #11 