### PR TITLE
Add infrastructure to bump versions of artifacts

### DIFF
--- a/.github/workflows/deploy-pre-release.yml
+++ b/.github/workflows/deploy-pre-release.yml
@@ -16,7 +16,6 @@ env:
   PYTHON_VERSION: '3.8'
   PROJECT_NAME: test-release-actions
   RUNS_ON: ubuntu-20.04
-  PUBLISH_TO_PYPI_TEST: false
 
 jobs:
 
@@ -122,7 +121,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure Poetry to use Pypi Repository
-        if: ${{ PUBLISH_TO_PYPI_TEST }}
+        if: ${{ false }}
         run: |
           poetry config repositories.test-pypi https://test.pypi.org/legacy/
           poetry config pypi-token.test-pypi ${{ secrets.TEST_PYPI_TOKEN }}

--- a/.github/workflows/deploy-pre-release.yml
+++ b/.github/workflows/deploy-pre-release.yml
@@ -16,6 +16,7 @@ env:
   PYTHON_VERSION: '3.8'
   PROJECT_NAME: test-release-actions
   RUNS_ON: ubuntu-20.04
+  PUBLISH_TO_PYPI_TEST: ${{ false }}
 
 jobs:
 
@@ -121,10 +122,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure Poetry to use Pypi Repository
+        if: ${{ PUBLISH_TO_PYPI_TEST }}
         run: |
           poetry config repositories.test-pypi https://test.pypi.org/legacy/
           poetry config pypi-token.test-pypi ${{ secrets.TEST_PYPI_TOKEN }}
-
-      - name: Publish to test-pypi
-        run: |
           poetry publish -r test-pypi

--- a/.github/workflows/deploy-pre-release.yml
+++ b/.github/workflows/deploy-pre-release.yml
@@ -22,8 +22,6 @@ jobs:
   bump_version:
     environment: test_env
     runs-on: ubuntu-20.04
-    # Only run this job if the commit message doesn't start with release sentinel.
-    if: "!startsWith(github.event.head_commit.message, '[RELEASE]')"
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"

--- a/.github/workflows/deploy-pre-release.yml
+++ b/.github/workflows/deploy-pre-release.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           # current_tag is the last tagged relese in the repository.   From there
           # we need to remove the v from the begining of the tag.
-          if $(git tag -l "v*"); then
+          if ! $(git tag -l "v*" = ''); then
             current_tag=$(git tag -l "v*" | sort --reverse |sed -n 1p)
           else
             current_tag=v10.0.0

--- a/.github/workflows/deploy-pre-release.yml
+++ b/.github/workflows/deploy-pre-release.yml
@@ -16,7 +16,7 @@ env:
   PYTHON_VERSION: '3.8'
   PROJECT_NAME: test-release-actions
   RUNS_ON: ubuntu-20.04
-  PUBLISH_TO_PYPI_TEST: ${{ false }}
+  PUBLISH_TO_PYPI_TEST: false
 
 jobs:
 

--- a/.github/workflows/deploy-pre-release.yml
+++ b/.github/workflows/deploy-pre-release.yml
@@ -1,0 +1,130 @@
+---
+name: Deploy Pre-Release Artifacts
+
+on:
+  push:
+    branches:
+      - develop
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  LANG: en_US.utf-8
+  LC_ALL: en_US.utf-8
+  PYTHON_VERSION: '3.8'
+  PROJECT_NAME: test-release-actions
+  RUNS_ON: ubuntu-20.04
+
+jobs:
+
+  bump_version:
+    environment: test_env
+    runs-on: ubuntu-20.04
+    # Only run this job if the commit message doesn't start with release sentinel.
+    if: "!startsWith(github.event.head_commit.message, '[RELEASE]')"
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+
+      #----------------------------------------------
+      #       check-out repo and set-up python
+      #----------------------------------------------
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        id: setup-python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      #----------------------------------------------
+      #  -----  install & configure poetry  -----
+      #----------------------------------------------
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
+      #----------------------------------------------
+      #       load cached venv if cache exists
+      #----------------------------------------------
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v2.1.7
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+
+      #----------------------------------------------
+      # install dependencies if cache does not exist
+      #----------------------------------------------
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
+
+      #----------------------------------------------
+      # install your root project, if required
+      #----------------------------------------------
+      - name: Install library
+        run: |
+          poetry install --no-interaction
+
+      #----------------------------------------------
+      # bump version number for patch
+      #----------------------------------------------
+      - name: Bump Version
+        run: |
+          # current_tag is the last tagged relese in the repository.   From there
+          # we need to remove the v from the begining of the tag.
+          if $(git tag -l "v*"); then
+            current_tag=$(git tag -l "v*" | sort --reverse |sed -n 1p)
+          else
+            current_tag=v10.0.0
+          fi
+
+          current_tag=${current_tag#?}
+
+          # current_tag is now the version we want to set our poetry version so
+          # that we can bump the version
+          poetry version ${current_tag}
+          poetry version prerelease --no-interaction
+
+          NEW_TAG=v$(poetry version --short)
+
+          # Finally because we want to be able to use the variable in later
+          # steps we set a NEW_TAG environmental variable
+          echo "NEW_TAG=$(echo ${NEW_TAG})" >> $GITHUB_ENV
+
+      #---------------------------------------------------------------
+      # create build artifacts to be included as part of release
+      #---------------------------------------------------------------
+      - name: Create build artifacts
+        run: |
+          poetry build -vvv
+
+      - uses: ncipollo/release-action@v1
+        with:
+          artifacts: "dist/*.gz,dist/*.whl"
+          artifactErrorsFailBuild: true
+          generateReleaseNotes: true
+          commit: ${{ github.ref }}
+          prerelease: true
+          tag: ${{ env.NEW_TAG }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Poetry to use Pypi Repository
+        run: |
+          poetry config repositories.test-pypi https://test.pypi.org/legacy/
+          poetry config pypi-token.test-pypi ${{ secrets.TEST_PYPI_TOKEN }}
+
+      - name: Publish to test-pypi
+        run: |
+          poetry publish -r test-pypi


### PR DESCRIPTION
This pull request addresses the need for establishing a release pattern that allows intermediate testing of wheel files.  It creates a new github action 'Deploy Pre-Release Artifacts' which does the following:

1. Installs poetry
2. Searches the git tags that have been published before to find the 'last' i.e. current tag
3. Parses the tag name (this should be in the form v10.0.0 or otherwise)  
5. Updates the pyproject.yml file to the next semantic patch version.
6. Builds the project
7. Releases the artifacts to github

The plumbing is there and has been tested to publish to pypi's test instance.  Remove the if condition from the final step block.

Fixes #19 
