### PR TITLE
Fixes 30 vctl status fails when installed

### DIFF
--- a/volttron/client/commands/__init__.py
+++ b/volttron/client/commands/__init__.py
@@ -52,32 +52,13 @@ import sys
 from configparser import ConfigParser
 from urllib.parse import urlparse
 
-from volttron.utils import jsonapi
+from volttron.utils import jsonapi, get_version
 from volttron.utils.frozendict import FrozenDict
 
 
 _log = logging.getLogger(__name__)
 
-# python3.8 and above have this implementation.
-try:
-    import importlib.metadata as importlib_metadata
-except ModuleNotFoundError:
-    import importlib_metadata
-
-# We should be in a develop environment therefore
-# we can get the version from the toml pyproject.toml
-root = Path(__file__).parent.parent.parent.parent
-tomle_file = root.joinpath("pyproject.toml")
-if not tomle_file.exists():
-    raise ValueError(
-        f"Couldn't find pyproject.toml file for finding version. ({str(tomle_file)})"
-    )
-import toml
-
-pyproject = toml.load(tomle_file)
-
-__version__ = pyproject["tool"]["poetry"]["version"]
-
+__version__ = get_version()
 
 # def get_volttron_root():
 #     """

--- a/volttron/server/__init__.py
+++ b/volttron/server/__init__.py
@@ -36,26 +36,6 @@
 # under Contract DE-AC05-76RL01830
 # }}}
 
-from pathlib import Path
-# python3.8 and above have this implementation.
-import importlib.metadata as importlib_metadata
+from volttron.utils import get_version
 
-# Try to get the version from written metadata, but
-# if failed then get it from the pyproject.toml file
-try:
-    # Note this is the wheel prefix or the name attribute in pyproject.toml file.
-    __version__ = importlib_metadata.version('volttron')
-except importlib_metadata.PackageNotFoundError:
-    # We should be in a develop environment therefore
-    # we can get the version from the toml pyproject.toml
-    root = Path(__file__).parent.parent.parent
-    tomle_file = root.joinpath("pyproject.toml")
-    if not tomle_file.exists():
-        raise ValueError(
-            f"Couldn't find pyproject.toml file for finding version. ({str(tomle_file)})"
-        )
-    import toml
-
-    pyproject = toml.load(tomle_file)
-
-    __version__ = pyproject["tool"]["poetry"]["version"]
+__version__ = get_version()


### PR DESCRIPTION
Closing #30 

The fix creates a utility function `get_version()` that handles both cases for retrieving the version.  Both client and server need this functionality for its use case.  Backward compatibility is maintained by handling the creation of __version__ for the modules.