### PR TITLE
update-make-release

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -31,12 +31,15 @@ on:
         required: false
         default: 600
         type: number
-      publish-to-test-pypi:
-        description: 'Set to true if you want to publish to https://test.pypi.org/legacy/ instead of pypi.org'
+      publish-option:
+        description: 'Choose where to publish: pypi, test-pypi, or none'
         required: false
-        default: false
-        type: boolean
-      
+        default: 'none'
+        type: choice
+        options:
+          - pypi
+          - test-pypi
+          - none
 
 defaults:
   run:
@@ -59,7 +62,7 @@ jobs:
       release-version: ${{ inputs.release-version }}
       bump-rule: ${{ inputs.bump-rule }}
       run-tests-wait: 600
-      publish-to-test-pypi: false
+      publish-option: ${{ inputs.publish-option }}
     secrets:
       git-token: ${{ secrets.AUTO_PROJECT_PAT }}
       pypi-token: ${{ secrets.PYPI_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,13 @@ packages = [
     { include = "volttron", from = "src" }
 ]
 
+include = [
+    "bom_reports/**/*"
+]
+
 [tool.poetry.dependencies]
-poetry = "^1.2.2"
 python = "^3.10"
+poetry = "^1.2.2"
 pyzmq = "^25.0.2"
 gevent = "^22.10.2"
 PyYAML = "^6.0"
@@ -35,15 +39,15 @@ psutil = "^5.9.0"
 cryptography = "^36.0.1"
 watchdog-gevent = "^0.1.1"
 pip = "22.2.2"
-pytest-timeout = "^2.1.0"
-pytest-mock = "^3.10.0"
+deprecated = "^1.2.14"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^6.2.5"
+pytest-timeout = "^1.4.2"  # Compatible with pytest < 7
+pytest-mock = "^3.10.0"
 mock = "^4.0.3"
 pre-commit = "^2.17.0"
 yapf = "^0.32.0"
-toml = "^0.10.2"
 mypy = "^1.2.0"
 
 [build-system]


### PR DESCRIPTION
The changes made in the PR focus on improving the flexibility of publishing options, adding SBOM generation, and cleaning up the dependency management. Here's a detailed breakdown:

Publish Option:

Old Code: The publish-to-test-pypi input was a boolean value.
New Code: The publish-option input is introduced as a choice type with valid options: pypi, test-pypi, or none. This enhances the flexibility by allowing users to choose the publishing target or skip publishing altogether.
SBOM Generation:

### Reason for the Change in the PR

#### Highlighted Changes

1. **Publish Option**:
   - **Old Code**:
     ```yaml
     publish-to-test-pypi:
       description: 'Set to true if you want to publish to https://test.pypi.org/legacy/ instead of pypi.org'
       required: false
       default: false
       type: boolean
     ```
   - **New Code**:
     ```yaml
     publish-option:
       description: 'Choose where to publish: pypi, test-pypi, or none'
       required: false
       default: 'none'
       type: choice
       options:
         - pypi
         - test-pypi
         - none
     ```
   - **Significance**: This change introduces more flexibility by allowing the user to specify whether to publish to PyPI, Test PyPI, or none, instead of just a boolean for Test PyPI. This is more user-friendly and versatile for different deployment scenarios.

2. **Inclusion of SBOM (Software Bill of Materials)**:
   - **New Additions**:
     ```yaml
     include = [
         "bom_reports/**/*"
     ]
     ```
   - **Significance**: Adding SBOM ensures that all software dependencies are tracked and vulnerabilities are reported. This is crucial for security and compliance, as it provides transparency into the components used in the project.

3. **Dependency Updates**:
   - **Old Code**:
     ```yaml
     poetry = "^1.2.2"
     pytest-timeout = "^2.1.0"
     pytest-mock = "^3.10.0"
     ```
   - **New Code**:
     ```yaml
     poetry = "^1.2.2"
     deprecated = "^1.2.14"
     pytest-timeout = "^1.4.2"  # Compatible with pytest < 7
     pytest-mock = "^3.10.0"
     ```
   - **Significance**: Dependencies were restructured to ensure compatibility and to align with the new development practices. The `pytest-timeout` was moved to dev dependencies, and a new dependency `deprecated` was added. This organization ensures the development environment is properly configured without cluttering the production environment.

4. **Stashing Local Changes**:
   - **New Additions**:
     ```yaml
     git stash push -u -m "Stash local changes before checkout"
     ```
   - **Significance**: This change ensures that any local changes are stashed before checking out to another branch, avoiding conflicts and errors related to uncommitted changes. This makes the process more robust and prevents potential data loss.


cross ref: https://github.com/eclipse-volttron/github-tooling/pull/33

# Verification:
Idea: using volttron-core for testing: (skip the publish to pypi/test-pypi steps)
* github action: https://github.com/kefeimo/volttron-core/actions/runs/9980409422/job/27581705767 
* inspect the released artificat/wheel: https://github.com/kefeimo/volttron-core/releases/tag/v10.0.1a34
    * 
![image](https://github.com/user-attachments/assets/60fc1bff-8ccd-4df3-b6e6-e390c1419fe1)