### PR TITLE
improve startup reliability — early PID file, --background flag, and resilient poetry setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ Note: you can also run ```pip install volttron-zmq``` or install the three packa
  1. **Start the platform:**
 
     ```bash
+    volttron -vv -l volttron.log --background
+    ```
+
+    The `--background` flag starts the platform as a detached process and displays a spinner while it initializes.
+    Once the platform is fully ready, it prints:
+
+    ```
+    VOLTTRON platform is running. [PID: 12345]
+    ```
+
+    At that point, `vctl status` and other commands will work immediately.
+
+    You can also start the platform the traditional way (without readiness feedback):
+
+    ```bash
     volttron -vv -l volttron.log &>/dev/null &
     ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "volttron-core"
-version = "2.0.0rc26"
+version = "2.0.0rc27"
 description = "VOLTTRON™ is an open source platform for distributed sensing and control. The platform provides services for collecting and storing data from buildings and devices and provides an environment for developing applications which interact with that data."
 authors = ["volttron <volttron@pnnl.gov>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "volttron-core"
-version = "2.0.0rc25"
+version = "2.0.0rc26"
 description = "VOLTTRON™ is an open source platform for distributed sensing and control. The platform provides services for collecting and storing data from buildings and devices and provides an environment for developing applications which interact with that data."
 authors = ["volttron <volttron@pnnl.gov>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "volttron-core"
-version = "2.0.0rc24"
+version = "2.0.0rc25"
 description = "VOLTTRON™ is an open source platform for distributed sensing and control. The platform provides services for collecting and storing data from buildings and devices and provides an environment for developing applications which interact with that data."
 authors = ["volttron <volttron@pnnl.gov>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "volttron-core"
-version = "2.0.0rc27"
+version = "2.0.0rc28"
 description = "VOLTTRON™ is an open source platform for distributed sensing and control. The platform provides services for collecting and storing data from buildings and devices and provides an environment for developing applications which interact with that data."
 authors = ["volttron <volttron@pnnl.gov>"]
 license = "Apache-2.0"

--- a/src/volttron/server/aip.py
+++ b/src/volttron/server/aip.py
@@ -631,7 +631,7 @@ class AIPplatform:
             # it could be just a package-name(ex. volttron-listener)
             # or package-name with version constraints- ex. volttron-agent@latest, volttron-agent>=1.0.0
             # so match till we hit a character that is NOT alphanumeric character or  _ or -
-            m = re.match("[\w\-]+", source)
+            m = re.match(r"[\w\-]+", source)
             if m:
                 agent_or_lib_name = m[0]
 

--- a/src/volttron/server/run_server.py
+++ b/src/volttron/server/run_server.py
@@ -148,22 +148,20 @@ def _start_background(volttron_home: Path):
     # Build the same command minus --background
     cmd = [sys.argv[0]] + [a for a in sys.argv[1:] if a != "--background"]
     log_file = None
+    has_log_config = False
     for i, arg in enumerate(cmd):
         if arg in ("-l", "--log") and i + 1 < len(cmd):
             log_file = cmd[i + 1]
             break
+        if arg in ("-L", "--log-config"):
+            has_log_config = True
 
-    # start_new_session=True calls setsid(), placing the child in a brand-new
-    # process session with no controlling terminal.  This has two effects:
-    #   1. The child is no longer in the shell's process group, so closing the
-    #      terminal cannot send SIGHUP to it — it will keep running after logout.
-    #   2. Without a controlling terminal the child cannot receive Ctrl-C or
-    #      other terminal-generated signals from the parent shell.
-    # Redirecting all three standard streams to DEVNULL completes the detachment:
-    # without this, stdin would still refer to the terminal file descriptor and
-    # could cause the child to block or error when the terminal is closed.
-    # Together these flags are the Python equivalent of the classic double-fork
-    # / nohup pattern, but without needing a wrapper script.
+    # In background mode stdio is detached; without an explicit log destination
+    # default stderr logging would be discarded. Route logs to a default file.
+    if log_file is None and not has_log_config:
+        log_file = (volttron_home / "volttron.log").as_posix()
+        cmd.extend(["--log", log_file])
+
     proc = subprocess.Popen(
         cmd,
         stdin=subprocess.DEVNULL,

--- a/src/volttron/server/run_server.py
+++ b/src/volttron/server/run_server.py
@@ -153,9 +153,24 @@ def _start_background(volttron_home: Path):
             log_file = cmd[i + 1]
             break
 
-    devnull = open(os.devnull, "w")
-    proc = subprocess.Popen(cmd, stdout=devnull, stderr=devnull, start_new_session=True)
-    devnull.close()
+    # start_new_session=True calls setsid(), placing the child in a brand-new
+    # process session with no controlling terminal.  This has two effects:
+    #   1. The child is no longer in the shell's process group, so closing the
+    #      terminal cannot send SIGHUP to it — it will keep running after logout.
+    #   2. Without a controlling terminal the child cannot receive Ctrl-C or
+    #      other terminal-generated signals from the parent shell.
+    # Redirecting all three standard streams to DEVNULL completes the detachment:
+    # without this, stdin would still refer to the terminal file descriptor and
+    # could cause the child to block or error when the terminal is closed.
+    # Together these flags are the Python equivalent of the classic double-fork
+    # / nohup pattern, but without needing a wrapper script.
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
 
     pid_file = volttron_home / "VOLTTRON_PID"
     ready_file = volttron_home / "VOLTTRON_READY"

--- a/src/volttron/server/run_server.py
+++ b/src/volttron/server/run_server.py
@@ -28,6 +28,7 @@ from volttron.types import MessageBusStopHandler
 
 monkey.patch_socket()
 monkey.patch_ssl()
+import itertools
 import subprocess
 import argparse
 import importlib
@@ -37,6 +38,7 @@ import os
 import resource
 import stat
 import sys
+import time
 from logging import handlers
 from pathlib import Path
 
@@ -71,9 +73,22 @@ def run_server():
     volttron_home = Path(os.environ.get("VOLTTRON_HOME", "~/.volttron")).expanduser()
     os.environ["VOLTTRON_HOME"] = volttron_home.as_posix()
 
+    # Quick-parse for --background before doing any server-side setup.
+    # The background launcher is not the actual server process — it just
+    # spawns the real server and waits for it to become ready.
+    if "--background" in sys.argv:
+        _start_background(volttron_home)
+        return
+
     if is_volttron_running(volttron_home=volttron_home.as_posix()):
         sys.stderr.write(f"Another VOLTTRON instance is already running using this VOLTTRON home {volttron_home}\n")
         sys.exit(1)
+
+    # Write PID file immediately so vctl can detect us during the (potentially
+    # slow) poetry initialisation and service bring-up.
+    pid_file = os.path.join(volttron_home.as_posix(), "VOLTTRON_PID")
+    with open(pid_file, "w") as f:
+        f.write(str(os.getpid()))
 
     # Raise events that the volttron_home has been set.
     volttron_home_set_evnt.send(run_server)
@@ -109,14 +124,84 @@ def run_server():
     server_options.store()
 
     # create poetry project and poetry lock file in VOLTTRON_HOME
-    if dev_mode:
-        if not (server_options.poetry_project_path / "pyproject.toml").exists():
-            raise ValueError("VOLTTRON is run with --dev but unable to find pyproject.toml is current directory - "
-                             f"{server_options.poetry_project_path}")
-    else:
-        setup_poetry_project(server_options.poetry_project_path)
+    try:
+        if dev_mode:
+            if not (server_options.poetry_project_path / "pyproject.toml").exists():
+                raise ValueError("VOLTTRON is run with --dev but unable to find pyproject.toml is current directory - "
+                                 f"{server_options.poetry_project_path}")
+        else:
+            setup_poetry_project(server_options.poetry_project_path)
+    except Exception:
+        # Clean up PID file if we fail before start_volttron_process
+        # (start_volttron_process has its own finally block for later failures)
+        if os.path.exists(pid_file):
+            os.remove(pid_file)
+        raise
 
     start_volttron_process(server_options)
+
+
+def _start_background(volttron_home: Path):
+    """Re-launch the volttron command without --background as a detached
+    subprocess, then wait with a spinner until the platform signals readiness
+    (via VOLTTRON_READY) or fails."""
+    # Build the same command minus --background
+    cmd = [sys.argv[0]] + [a for a in sys.argv[1:] if a != "--background"]
+    log_file = None
+    for i, arg in enumerate(cmd):
+        if arg in ("-l", "--log") and i + 1 < len(cmd):
+            log_file = cmd[i + 1]
+            break
+
+    devnull = open(os.devnull, "w")
+    proc = subprocess.Popen(cmd, stdout=devnull, stderr=devnull, start_new_session=True)
+    devnull.close()
+
+    pid_file = volttron_home / "VOLTTRON_PID"
+    ready_file = volttron_home / "VOLTTRON_READY"
+    spinner = itertools.cycle(["|", "/", "-", "\\"])
+    timeout = 120  # seconds
+    start_time = time.monotonic()
+
+    try:
+        while True:
+            elapsed = time.monotonic() - start_time
+            if elapsed >= timeout:
+                break
+
+            # Check if the child process is still alive.
+            ret = proc.poll()
+            if ret is not None:
+                msg = "VOLTTRON failed to start (exit code {}).".format(ret)
+                if log_file:
+                    msg += " Check log: {}".format(log_file)
+                sys.stdout.write("\r\033[K")
+                sys.stdout.write(msg + "\n")
+                sys.exit(1)
+
+            if ready_file.exists():
+                sys.stdout.write("\r\033[K")
+                sys.stdout.write("VOLTTRON platform is running. [PID: {}]\n".format(proc.pid))
+                sys.exit(0)
+
+            sys.stdout.write("\rStarting VOLTTRON... {} ({:.0f}s)".format(next(spinner), elapsed))
+            sys.stdout.flush()
+
+            # Sleep until the next half-second boundary to keep the display steady.
+            next_tick = start_time + (int(elapsed / 0.5) + 1) * 0.5
+            time.sleep(max(0, next_tick - time.monotonic()))
+
+        # Timed out
+        sys.stdout.write("\r\033[K")
+        msg = "VOLTTRON startup timed out after {}s.".format(timeout)
+        if log_file:
+            msg += " Check log: {}".format(log_file)
+        sys.stdout.write(msg + "\n")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        sys.stdout.write("\r\033[K")
+        sys.stdout.write("Interrupted. VOLTTRON may still be starting in the background (PID: {}).\n".format(proc.pid))
+        sys.exit(130)
 
 
 def setup_poetry_project(python_project_path: Path):
@@ -170,7 +255,7 @@ def setup_poetry_project(python_project_path: Path):
         # Add these first so that these don't get overwritten by non-editable package's dependency
         # i.e. if pointing to volttron-core dir, add this to poetry first so that volttron-lib-auth that depends on
         # volttron-core from pypi won't overwrite the source package
-        pip_cmd = ["pip", "list", "--editable"]
+        pip_cmd = [sys.executable, "-m", "pip", "list", "--editable"]
         p = subprocess.Popen(pip_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = p.communicate()  # Use p2's output directly
         if p.returncode != 0:
@@ -188,11 +273,11 @@ def setup_poetry_project(python_project_path: Path):
                 raise RuntimeError("Unable to add editable package to $VOLTTRON_HOME/pyproject.toml:", stderr.decode())
 
         # now do multiple piped commands. add all non-editable packages in one go using piped cmd
-        pip_cmd = ["pip", "list", "--format", "freeze",  "--exclude-editable"]
+        # Use sys.executable to ensure we list only the current venv's packages, not system pip packages
+        # (bare 'pip' on PATH may resolve to the system pip when running inside a subprocess).
+        pip_cmd = [sys.executable, "-m", "pip", "list", "--format", "freeze", "--exclude-editable"]
         # Second command
         grep_cmd = ["grep", "-v", "volttron=="]
-        # Third command
-        poetry_cmd = ["xargs", "poetry", "add", "--directory", python_project_path.as_posix()]
 
         err_msg = ""
         # Execute the first command
@@ -213,11 +298,31 @@ def setup_poetry_project(python_project_path: Path):
                 if not p2_stdout.strip():
                     print("No packages to add; grep output is empty.")
                 else:
-                    # Execute the third command, with stdin from the second command's stdout
-                    p3 = subprocess.Popen(poetry_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-                    p3_stdout, p3_stderr = p3.communicate(input=p2_stdout)    # Use p2's output directly
-                    if p3.returncode != 0:
-                        err_msg = "Error from poetry command:", p3_stderr.decode()
+                    # Add packages via poetry, retrying and skipping any packages that cannot be
+                    # resolved from PyPI (e.g. system-only packages like cloud-init on Ubuntu/WSL).
+                    import re
+                    remaining = p2_stdout
+                    skipped = []
+                    while remaining.strip():
+                        poetry_cmd = ["xargs", "poetry", "add", "--directory", python_project_path.as_posix()]
+                        p3 = subprocess.Popen(poetry_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                        p3_stdout, p3_stderr = p3.communicate(input=remaining)
+                        if p3.returncode == 0:
+                            break
+                        # poetry 2.x prints errors to stdout; check both streams
+                        combined_out = p3_stdout.decode() + p3_stderr.decode()
+                        m = re.search(r'Could not find a matching version of package\s+(\S+)', combined_out)
+                        if not m:
+                            err_msg = "Error from poetry command:", combined_out
+                            break
+                        bad_pkg = m.group(1)
+                        skipped.append(bad_pkg)
+                        _log.warning(f"Skipping package {bad_pkg!r}: not available via poetry (not on PyPI).")
+                        filtered = [line for line in remaining.decode().splitlines()
+                                    if not line.strip().lower().startswith(bad_pkg.lower() + "==")]
+                        remaining = ("\n".join(filtered) + "\n").encode()
+                    if skipped:
+                        _log.info(f"The following packages were skipped (not available on PyPI): {skipped}")
 
         if err_msg:
             err_msg = (f"Unable to update pyproject.toml in {python_project_path.as_posix()} with venv's current list of "
@@ -373,6 +478,12 @@ def start_volttron_process(options: ServerOptions):
                              "and attempts to restart. {}".format(e))
 
     pid_file = os.path.join(opts.volttron_home.as_posix(), "VOLTTRON_PID")
+    ready_file = os.path.join(opts.volttron_home.as_posix(), "VOLTTRON_READY")
+
+    # Remove a stale readiness marker from a previous run.
+    if os.path.exists(ready_file):
+        os.remove(ready_file)
+
     try:
         _log.debug("********************************************************************")
         _log.debug("VOLTTRON PLATFORM RUNNING ON {} MESSAGEBUS".format(opts.messagebus))
@@ -511,9 +622,8 @@ def start_volttron_process(options: ServerOptions):
             for name, error in opts.aip.autostart():
                 _log.error("error starting {!r}: {}\n".format(name, error))
 
-        # Done with all start up process write a PID file
-
-        with open(pid_file, "w+") as f:
+        # Signal that the platform is fully ready.
+        with open(ready_file, "w") as f:
             f.write(str(os.getpid()))
 
         if opts.enable_federation:
@@ -548,6 +658,8 @@ def start_volttron_process(options: ServerOptions):
             instances.sync()
             if os.path.exists(pid_file):
                 os.remove(pid_file)
+            if os.path.exists(ready_file):
+                os.remove(ready_file)
         except Exception:
             _log.warning(f"Unable to load {VOLTTRON_INSTANCES_PATH}")
         _log.debug("********************************************************************")
@@ -685,6 +797,12 @@ def build_arg_parser(options: ServerOptions) -> argparse.ArgumentParser:
                         dest="dev_mode",
                         default=False,
                         help="development mode with poetry environment to build volttron libraries from source/pypi")
+    parser.add_argument(
+        "--background",
+        action="store_true",
+        default=False,
+        help="start the platform in the background and wait for it to be ready",
+    )
 
     parser.add_help_argument()
     parser.add_version_argument(version="%(prog)s " + str(get_version()))


### PR DESCRIPTION
## Description

### Problem

When starting VOLTTRON from a fresh install (`pip install volttron`) and launching in the background:

```bash
volttron -vv -l volttron.log &>/dev/null &
vctl status   # → "VOLTTRON is not running"
```

`vctl status` repeatedly reports "VOLTTRON is not running" for 15–30+ seconds on first launch. This happens because:

1. **`VOLTTRON_PID` was written at the very end of startup** — after poetry initialization, message bus startup, and all service agent spawning. Until that file exists, `vctl` (which checks for `VOLTTRON_PID`) has no way to know the platform is starting.

2. **`setup_poetry_project()` runs `poetry init` + `poetry add` for every installed package on first launch**, which takes 15+ seconds. During this entire time, no PID file exists.

3. **On systems where non-PyPI packages are visible** (e.g. `cloud-init` on Ubuntu), the `poetry add` command crashes with `Could not find a matching version of package cloud-init`, killing the startup silently.

4. **`pip list` was called as bare `pip`** in subprocess calls, which could resolve to the system pip instead of the venv's pip, pulling in system-only packages.

### Changes

#### 1. Early PID file write
`VOLTTRON_PID` is now written immediately in `run_server()`, before poetry setup or service initialization. This means `vctl status` can detect the platform during the entire startup process. The PID file is cleaned up if startup fails before reaching `start_volttron_process()`.

#### 2. `--background` flag with readiness indicator
New `volttron --background` flag that:
- Launches the actual server as a detached subprocess
- Displays a live spinner with elapsed time: `Starting VOLTTRON... | (12s)`
- Waits for a `VOLTTRON_READY` marker file (written after all services are up)
- Reports success: `VOLTTRON platform is running. [PID: 12345]`
- Reports failure with a pointer to the log file if the process exits
- Handles Ctrl+C gracefully
- Times out after 120 seconds

**Usage:**
```bash
# Instead of:
volttron -vv -l volttron.log &>/dev/null &
# Now:
volttron -vv -l volttron.log --background
```

#### 3. Resilient poetry setup (non-PyPI package handling)
`setup_poetry_project()` now catches `Could not find a matching version of package <name>` errors from poetry, skips the offending package, and retries. This handles system-only packages like `cloud-init`, `ubuntu-drivers-common`, etc. that appear in `pip list` but don't exist on PyPI.

#### 4. Use `sys.executable -m pip` instead of bare `pip`
Subprocess calls to `pip list` now use `[sys.executable, "-m", "pip", ...]` to ensure we always use the current venv's pip, not whatever `pip` resolves to on `PATH`.

### Files Changed
- `src/volttron/server/run_server.py` — all changes in this file

### Testing
Tested with fresh `VOLTTRON_HOME` directories:
- `volttron --background` shows spinner and returns once platform is ready
- `vctl status` works immediately after `--background` returns
- Platform starts successfully even when non-PyPI packages are installed
- PID file is cleaned up on startup failure and normal shutdown
- `VOLTTRON_READY` marker is cleaned up on shutdown