### PR TITLE
fix: loosen gevent pin to unblock downstream consumers on gevent 25.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ optional = true
 [tool.poetry.dependencies]
 poetry = "^2.0"
 python = "^3.10"
-gevent = ">=24.2.1,<24.3"
+gevent = ">=24.2.1"
 PyYAML = "^6.0"
 toml = "^0.10.2"
 dateutils = "^0.6.12"


### PR DESCRIPTION
## Problem

The current gevent pin `>=24.2.1,<24.3` prevents downstream packages that require
`gevent>=25.x` from installing alongside `volttron-core`. pip's dependency resolver
raises `ResolutionImpossible` and the install fails entirely.

## Fix

Remove the upper bound: `gevent = ">=24.2.1"`

gevent follows a date-based versioning scheme. There is no known breaking change in
the gevent 25.x series that would affect volttron-core. The `<24.3` upper bound
appears to have been added as a precaution but is now blocking legitimate use cases.

## Impact

- Any project depending on both `volttron-core` and `gevent>=25.x` is currently
  uninstallable via pip
- This is a **blocking issue** for downstream consumers (e.g. [AEMS FastAPI platform](https://github.com/VOLTTRON/aems-lib-fastapi)
  with `gevent~=25.9.1`) 

## Testing

The existing test suite should pass unchanged — no volttron-core code depends on
gevent 24.x-specific behavior.